### PR TITLE
split dataset for learn-fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 .DS_Store
+./dataset
+*.db
+*.csv
+*.npy
+*.db.sqbpro
+*.txt

--- a/PLY/lexical2.py
+++ b/PLY/lexical2.py
@@ -2,12 +2,15 @@ import ply.lex as lex
 import sqlite3
 import argparse
 import csv
+import os
 
 parser = argparse.ArgumentParser(description='generate dataset for learn-fixes')
 parser.add_argument('-d', '--dataset', default='./dataset.db', type=str)
+parser.add_argument('-o', '--output', default='', type=str)
 args = parser.parse_args()
 
 dataset = args.dataset
+outdir = args.output
 
 code_list = []
 
@@ -215,11 +218,14 @@ for raw_code_id, raw_code in code_list:
         flag += 1
         me_lis, va_lis, st_lis, ch_lis, in_lis, fl_lis, ty_lis = [], [], [], [], [], [], []
 
-with open( "./fixed.txt", "w" ) as f:
+if not os.path.exists( outdir ):
+    os.makedirs( outdir )
+
+with open( outdir + "./fixed.txt", "w" ) as f:
     for raw_code_id, cor_tokenized_code in cor_tokenized_list:
         f.write( str( cor_tokenized_code ) + "\n" )
 
-with open( "./buggy.txt", "w" ) as f:
+with open( outdir + "./buggy.txt", "w" ) as f:
     for raw_code_id, err_tokenized_code in err_tokenized_list:
         f.write( str( err_tokenized_code ) + "\n" )
 # i = 0

--- a/PLY/make_dic.py
+++ b/PLY/make_dic.py
@@ -1,24 +1,45 @@
-s = """
+import argparse
+import os 
 
-TYPE_1 main ( ) { TYPE_1 VAR_1 , VAR_2 , VAR_3 , VAR_4 ; METHOD_1 ( STRING_1 ) ; METHOD_2 ( STRING_2 , & VAR_4 ) ; for ( VAR_1 = INT_3 ; VAR_1 < = VAR_4 ; VAR_1 + + ) { for ( VAR_2 = INT_3 ; VAR_2 < = VAR_1 ; VAR_2 + + ) { METHOD_1 ( STRING_3 ) ; } return INT_3 ; }
-TYPE_1 main ( ) { TYPE_1 VAR_5 , VAR_6 , VAR_7 ; METHOD_1 ( STRING_4 ) ; METHOD_2 ( STRING_2 , & VAR_5 ) ; for ( VAR_7 = INT_3 ; VAR_7 < INT_6 ; VAR_7 + + ) { for ( VAR_6 = INT_3 ; VAR_6 < = VAR_7 ; VAR_6 + + ) { METHOD_1 ( STRING_5 ) ; } METHOD_1 ( STRING_6 ) ; } return INT_3 ; }
-TYPE_1 main ( TYPE_1 VAR_8 , TYPE_2 TYPE_3 * VAR_9 [ ] ) { TYPE_1 VAR_1 , VAR_2 , VAR_3 , VAR_4 ; METHOD_1 ( STRING_1 ) ; METHOD_2 ( STRING_2 , & VAR_4 ) ; for ( VAR_1 = INT_3 ; VAR_1 < = VAR_4 ; VAR_1 + + ) { for ( VAR_2 = INT_3 ; VAR_2 < = VAR_1 ; VAR_2 + + ) { METHOD_1 ( STRING_7 ) ; } return INT_3 ; }
-TYPE_1 main ( ) { TYPE_1 VAR_10 ; TYPE_1 VAR_11 ; TYPE_1 VAR_4 ; TYPE_3 VAR_12 = STRING_8 ; TYPE_1 VAR_13 ; METHOD_1 ( STRING_9 ) ; METHOD_2 ( STRING_2 , & VAR_4 ) ; VAR_13 = VAR_4 ; for ( VAR_11 = INT_3 ; VAR_11 < VAR_13 ; VAR_11 + + ) { for ( VAR_10 = INT_3 ; VAR_10 < VAR_4 ; VAR_10 + + ) { METHOD_1 ( STRING_10 , VAR_12 ) ; } METHOD_1 ( STRING_6 ) ; VAR_4 - = INT_11 ; } return INT_3 ; }
-TYPE_1 main ( ) { TYPE_1 VAR_10 , VAR_14 , VAR_1 ; METHOD_2 ( STRING_2 , & VAR_1 ) ; for ( VAR_10 = INT_11 ; VAR_10 < = VAR_1 ; VAR_10 + + ) { for ( VAR_14 = INT_11 ; VAR_14 < = VAR_10 ; VAR_14 + + ) { METHOD_1 ( STRING_5 ) ; } METHOD_1 ( STRING_6 ) ; } return INT_3 ; }
-TYPE_1 main ( ) { TYPE_1 VAR_6 , VAR_7 ; for ( VAR_7 = INT_3 ; VAR_7 < INT_6 ; VAR_7 + + ) { for ( VAR_6 = INT_3 ; VAR_6 < = VAR_7 ; VAR_6 + + ) { METHOD_1 ( STRING_11 ) ; } METHOD_1 ( STRING_6 ) ; } return INT_3 ; }
-TYPE_1 main ( TYPE_1 VAR_8 , TYPE_2 TYPE_3 * VAR_9 [ ] ) { TYPE_1 VAR_1 , VAR_2 , VAR_3 , VAR_4 ; METHOD_1 ( STRING_1 ) ; METHOD_2 ( STRING_2 , & VAR_4 ) ; for ( VAR_1 = INT_3 ; VAR_1 < = VAR_4 ; VAR_1 + + ) { for ( VAR_2 = INT_3 ; VAR_2 < = VAR_1 ; VAR_2 + + ) { METHOD_1 ( STRING_7 ) ; } return INT_3 ; }
-TYPE_1 main ( ) { TYPE_1 VAR_10 , VAR_14 ; TYPE_3 & ; METHOD_2 ( STRING_12 ) ; for ( VAR_14 = INT_11 ; VAR_14 < = VAR_10 ; VAR_14 + + ) { METHOD_1 ( STRING_13 , & = VAR_14 ) ; } return INT_3 ; }
-TYPE_1 main ( ) { TYPE_1 VAR_5 , VAR_10 , VAR_14 ; for ( VAR_10 = INT_11 ; VAR_10 < = VAR_5 ; VAR_10 + + ) { for ( VAR_14 = INT_11 ; VAR_14 < = VAR_10 ; VAR_14 + + ) { METHOD_1 ( STRING_14 ) ; } METHOD_1 ( STRING_6 ) ; } METHOD_2 ( STRING_15 ) ; return INT_3 ; }
-TYPE_1 main ( ) { TYPE_1 VAR_12 ; TYPE_1 VAR_4 ; METHOD_1 ( STRING_16 ) ; METHOD_2 ( STRING_2 , & VAR_4 ) ; for ( VAR_12 = INT_3 ; VAR_12 < = VAR_4 ; VAR_12 + + ) { METHOD_1 ( STRING_17 , VAR_12 ) ; } return INT_3 ; }
-"""
+parser = argparse.ArgumentParser(description='make dic from dataset for learn-fixes')
+parser.add_argument('-i', '--in_dir', default='./', type=str)
+parser.add_argument('-o', '--out_dir', default='./', type=str)
+args = parser.parse_args()
 
-words = s.split()
-dic = {}
-for w in words:
-    try:
-        dic[ w ] += 1
-    except KeyError:
-        dic[ w ] = 1
+in_dir = args.in_dir
+out_dir = args.out_dir
 
-for w in dic.keys():
-    print( str( w ) + "\t" + str( dic[ w ] ) )
+buggy_dic = {}
+with open( in_dir + "/buggy.txt" ) as f:
+    s_list = f.readlines()
+    for s in s_list:
+        words = s.split()
+        for w in words:
+            try:
+                buggy_dic[ w ] += 1
+            except KeyError:
+                buggy_dic[ w ] = 1
+
+fixed_dic = {}
+with open( in_dir + "/fixed.txt" ) as f:
+    s_list = f.readlines()
+    for s in s_list:
+        words = s.split()
+        for w in words:
+            try:
+                fixed_dic[ w ] += 1
+            except KeyError:
+                fixed_dic[ w ] = 1
+
+if not os.path.exists( out_dir ):
+    os.makedirs( out_dir )
+
+with open( out_dir + "/vocab.buggy.txt", "w" ) as f:
+    for w in buggy_dic.keys():
+        # print( str( w ) + "\t" + str( buggy_dic[ w ] ) )
+        f.write( str( w ) + "\t" + str( buggy_dic[ w ] ) )
+
+with open( out_dir + "/vocab.fixed.txt", "w" ) as f:
+    for w in fixed_dic.keys():
+        # print( str( w ) + "\t" + str( fixed_dic[ w ] ) )
+        f.write( str( w ) + "\t" + str( fixed_dic[ w ] ) )

--- a/data_split/data_split.py
+++ b/data_split/data_split.py
@@ -1,0 +1,72 @@
+import sqlite3
+import argparse
+import random
+import os
+
+parser = argparse.ArgumentParser(description='split the dataset into train, eval and test')
+parser.add_argument('-d', '--dataset', default='./dataset.db', type=str)
+parser.add_argument('-e', '--eval_rate', default=0.10, type=float)
+parser.add_argument('-t', '--test_rate', default=0.10, type=float)
+parser.add_argument('-o', '--out_dir', default='', type=str)
+args = parser.parse_args()
+
+dataset = args.dataset
+eval_rate = args.eval_rate
+test_rate = args.test_rate
+out_dir = args.out_dir
+
+def save_database( which, user_list, out ):
+    if not os.path.exists( out+ "/" + which ):
+        os.makedirs( out + "/" + which )
+
+    new_db = out + "/" + which + "/" + "dataset.db"
+
+    with sqlite3.connect( new_db ) as new_conn:
+        new_cursor = new_conn.cursor()
+        new_cursor.execute( 'CREATE TABLE "Code" ( "code_id" TEXT,"user_id" TEXT, "problem_id" TEXT, "code" TEXT, "error" TEXT, "errorcount" INTEGER, PRIMARY KEY("code_id"))' )
+
+        with sqlite3.connect( dataset ) as conn:
+            cursor = conn.cursor()
+
+            for user in user_list:
+                for line in cursor.execute( 'SELECT * FROM Code WHERE user_id="' + user + '"' ):
+                    code_id     = str( line[ 0 ] )
+                    user_id     = str( line[ 1 ] )
+                    prob_id     = str( line[ 2 ] )
+                    code        = str( line[ 3 ] )
+                    error       = str( line[ 4 ] )
+                    errorcount  = str( line[ 5 ] )
+
+                    # print( code_id, user_id, prob_id, code, error, errorcount )
+
+                    sql_insert = 'INSERT INTO Code( code_id, user_id, problem_id, code, error, errorcount ) values( ?, ?, ?, ?, ?, ? )'
+                    new_cursor.execute( sql_insert, [ code_id, user_id, prob_id, code, error, errorcount ] )
+
+            cursor.close()
+
+        new_cursor.close()
+
+
+with sqlite3.connect( dataset ) as conn:
+    cursor = conn.cursor()
+
+    user_list = []
+    for line in cursor.execute( "SELECT DISTINCT user_id FROM Code" ):
+        user_id = str( line[ 0 ] )
+        user_list.append( user_id )
+
+    random.shuffle( user_list )
+    datasize = len( user_list )
+    index_e = int( datasize * eval_rate )
+    index_t = index_e + int( datasize * test_rate )
+    eval_list = user_list[ : index_e ]
+    test_list = user_list[ index_e : index_t ]
+    train_list = user_list[ index_t : ]
+
+    cursor.close()
+
+if not os.path.exists( out_dir ):
+    os.makedirs( out_dir )
+save_database( "train", train_list, "./" + out_dir )
+save_database( "eval", eval_list, "./" + out_dir )
+save_database( "test", test_list, "./" + out_dir )


### PR DESCRIPTION
データセットをlearn-fixes向けにtrain，eval，testの3つへと分割するためのコードを書きました．
ついでに，字句解析部分の入出力も少し変更しました．

## テスト方法
- data_split
  - data_split.py
- dataset
  - dataset.db
- PLY
  - lexical1.py
  - lexical2.py
  - make_dic.py

例えば上のようなディレクトリがあるとき，カレントディレクトリで
```
python3 data_split/data_split.py -d dataset/dataset.db -o output
```
を実行すると，./output/にtrain，eval，testディレクトリができ，その中にそれぞれdataset.dbが生成されます．さらに，
```
python3 PLY/lexical2.py -d output/eval/dataset.db -o output/eval/
python3 PLY/make_dic.py -i output/eval/ -o output/eval/
```
を実行すると，./output/eval/にeval用のbuggy.txt，fixed.txt，vocab.buggy.txt，vocab.fixed.txtが生成されます．

## テストの成功例
- outputディレクトリに，learn-fixesの入力ファイルが生成されます．
- train，eval，testはユーザー単位で8:1:1に分割されます（data_split.pynのオプション引数で変更できます．）．
- train，eval，testにはそれぞれ異なるユーザのデータが使われます（学習モデルのカンニングを防ぐため．）．